### PR TITLE
IdeaVim: Improve match and view mode support, fix reformat code binding

### DIFF
--- a/helix.idea.vim
+++ b/helix.idea.vim
@@ -1509,8 +1509,13 @@ nnoremap * v"ay:<C-u>let @/='<C-r>a'<CR>
 xnoremap * "ay:<C-u>let @/='<C-r>a'<CR>
 
 " View mode
+xmap zz <Action>(EditorScrollToCenter)
+nmap zz <Action>(EditorScrollToCenter)
+xmap zc <Action>(EditorScrollToCenter)
 nmap zc <Action>(EditorScrollToCenter)
+xmap zj <Action>(EditorScrollDownAndMove)
 nmap zj <Action>(EditorScrollDownAndMove)
+xmap zk <Action>(EditorScrollUpAndMove)
 nmap zk <Action>(EditorScrollUpAndMove)
 
 " Unimpaired

--- a/helix.idea.vim
+++ b/helix.idea.vim
@@ -1470,6 +1470,14 @@ set argtextobj
 nmap maa vaa
 xmap maa vaa
 
+set surround
+unmap cs
+unmap ds
+unmap ys
+unmap yss
+nmap mr <Plug>CSurround
+nmap md <Plug>DSurround
+
 " Goto mode
 nmap gr <Action>(FindUsages)
 nmap gi <Action>(GotoImplementation)

--- a/helix.idea.vim
+++ b/helix.idea.vim
@@ -1459,7 +1459,8 @@ set wrapscan                      " searches wrap around the end of the file
 
 set ideajoin
 
-xnoremap \= <Action>(ReformatCode)
+nmap = <Action>(ReformatCode)
+xmap = <Action>(ReformatCode)
 
 noremap X 0V
 xnoremap X <nop>

--- a/src/helix.idea.vim
+++ b/src/helix.idea.vim
@@ -23,6 +23,14 @@ set argtextobj
 nmap maa vaa
 xmap maa vaa
 
+set surround
+unmap cs
+unmap ds
+unmap ys
+unmap yss
+nmap mr <Plug>CSurround
+nmap md <Plug>DSurround
+
 " Goto mode
 nmap gr <Action>(FindUsages)
 nmap gi <Action>(GotoImplementation)

--- a/src/helix.idea.vim
+++ b/src/helix.idea.vim
@@ -62,8 +62,13 @@ nnoremap * v"ay:<C-u>let @/='<C-r>a'<CR>
 xnoremap * "ay:<C-u>let @/='<C-r>a'<CR>
 
 " View mode
+xmap zz <Action>(EditorScrollToCenter)
+nmap zz <Action>(EditorScrollToCenter)
+xmap zc <Action>(EditorScrollToCenter)
 nmap zc <Action>(EditorScrollToCenter)
+xmap zj <Action>(EditorScrollDownAndMove)
 nmap zj <Action>(EditorScrollDownAndMove)
+xmap zk <Action>(EditorScrollUpAndMove)
 nmap zk <Action>(EditorScrollUpAndMove)
 
 " Unimpaired

--- a/src/helix.idea.vim
+++ b/src/helix.idea.vim
@@ -12,7 +12,8 @@ set wrapscan                      " searches wrap around the end of the file
 
 set ideajoin
 
-xnoremap \= <Action>(ReformatCode)
+nmap = <Action>(ReformatCode)
+xmap = <Action>(ReformatCode)
 
 noremap X 0V
 xnoremap X <nop>


### PR DESCRIPTION
**Summary**
- Fix reformat code binding (`=`)
- Support match mode surround replace (`mr`) and surround delete (`md`) using builtin `vim-surround` plugin
- Support view mode bindings also in visual mode
- Support alternate binding to align view center (`zz`)